### PR TITLE
Fix bug where repo directory is not fully deleted (#27)

### DIFF
--- a/src/main/java/group10/GitRunner.java
+++ b/src/main/java/group10/GitRunner.java
@@ -21,11 +21,13 @@ public class GitRunner {
         repoDir.mkdir();
 
         // clone the repo from the given branch
-        Git.cloneRepository()
+        Git git = Git.cloneRepository()
                 .setURI(repoURL)
                 .setDirectory(new File("./" + directory))
                 .setBranch("refs/heads/" + branch)
                 .call();
+
+        git.close();
     }
 
     /**
@@ -37,7 +39,6 @@ public class GitRunner {
             for (File subFile : dir.listFiles()) {
                 if (subFile.isDirectory()) deleteDir(subFile);
                 subFile.delete();
-
             }
             dir.delete();
         }

--- a/src/test/java/group10/GitRunnerTest.java
+++ b/src/test/java/group10/GitRunnerTest.java
@@ -43,4 +43,16 @@ public class GitRunnerTest {
         assertTrue(repoDir.exists());
         GitRunner.deleteDir(new File("./test2"));
     }
+
+    /**
+     * Assert false
+     * Try cloning a repo and deleting it, then check if the directory exists
+     * @throws GitAPIException
+     */
+    @Test
+    public void testGitRunner_CloneRepo_Negative() throws GitAPIException {
+        GitRunner.cloneRepo("https://github.com/hannes-ha/DD2480-Assignment2.git", "main", "test3");
+        GitRunner.deleteDir(new File("./test3"));
+        assertFalse(new File("./test3").exists());
+    }
 }


### PR DESCRIPTION
Fixed cloneRepo function so that git is closed after cloning. This allows for fully deleting the repo directory after it has been used. Resolves #27.